### PR TITLE
Use map for visited nodes in Cayley graph

### DIFF
--- a/docs/ts/Group.js
+++ b/docs/ts/Group.js
@@ -19,6 +19,7 @@ export class Group {
     get cayley() {
         const graph = [[this.id, []]];
         const visited = [this.id];
+        const visitedMap = new Map([[this.id.key(), 0]]);
         const stack = [0];
         while (stack.length > 0) {
             const nidx = stack.pop();
@@ -26,11 +27,12 @@ export class Group {
             this.gens.forEach((g) => {
                 // left multiplication
                 const h = g.mul(e);
-                const idx = visited.indexOf(h);
-                if (idx == -1) {
+                const idx = visitedMap.get(h.key());
+                if (idx === undefined) {
                     cs.push(graph.length);
                     stack.push(graph.length);
                     visited.push(h);
+                    visitedMap.set(h.key(), visited.length - 1);
                     graph.push([h, []]);
                     return;
                 }
@@ -44,6 +46,9 @@ export class GroupElement {
     constructor(grp, mat) {
         this.grp = grp;
         this.mat = mat;
+    }
+    key() {
+        return JSON.stringify(this.mat.mat);
     }
     mul(o) {
         assert(this.grp == o.grp, "Multiplying elements of different groups");

--- a/ts/Group.ts
+++ b/ts/Group.ts
@@ -37,6 +37,7 @@ export class Group {
   get cayley(): CayleyGraph {
     const graph: CayleyGraph = [[this.id, []]];
     const visited: GroupElement[] = [this.id];
+    const visitedMap: Map<string, number> = new Map([[this.id.key(), 0]]);
     const stack: number[] = [0];
     while (stack.length > 0) {
       const nidx = stack.pop()!;
@@ -45,11 +46,12 @@ export class Group {
       this.gens.forEach((g) => {
         // left multiplication
         const h = g.mul(e);
-        const idx = visited.indexOf(h);
-        if (idx == -1) {
+        const idx = visitedMap.get(h.key());
+        if (idx === undefined) {
           cs.push(graph.length);
           stack.push(graph.length);
           visited.push(h);
+          visitedMap.set(h.key(), visited.length - 1);
           graph.push([h, []]);
           return;
         }
@@ -62,6 +64,10 @@ export class Group {
 
 export class GroupElement {
   constructor(readonly grp: Group, readonly mat: Matrix) {}
+
+  key(): string {
+    return JSON.stringify(this.mat.mat);
+  }
 
   mul(o: GroupElement): GroupElement {
     assert(this.grp == o.grp, "Multiplying elements of different groups");


### PR DESCRIPTION
## Summary
- add a `key()` method for `GroupElement`
- track visited elements in `Group.cayley` via `Map`
- update generated JS

## Testing
- `npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_6847cf592970832f8ba476ad5272de41